### PR TITLE
Added stop to robots

### DIFF
--- a/vsss_ws/src/strategy/strategy/field/robot.py
+++ b/vsss_ws/src/strategy/strategy/field/robot.py
@@ -2,6 +2,7 @@ import math
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
+from std_msgs.msg import Bool
 from .entity import Entity
 from .. import constants
 
@@ -27,6 +28,7 @@ class Robot(Entity):
         self.mark_ids = []
 
         self.sub_cmd_vel = None
+        self.sub_stop = None
 
         if simulation:
             self.subscribe_to_topics()
@@ -38,14 +40,29 @@ class Robot(Entity):
             self._simulation_move,
             10
         )
+        self.sub_stop = self.ros_handler.create_subscription(
+            Bool,
+            f'/strategy/robot_{self.id}/stop',
+            self._simulation_stop,
+            10
+        )
 
     def _simulation_move(self, msg):
         self.real_vx = msg.linear.x
         self.real_vy = msg.linear.y
         self.real_theta_vel = msg.angular.z
 
+    def _simulation_stop(self, msg):
+        if msg.data:
+            print("Stop robot with id {}".format(self.id))
+            self.real_vx = 0
+            self.real_vy = 0
+
+    def stop(self):
+        self.ros_handler.publish_stop(self.id, True)
 
     def move(self, speed, angle):
+        self.ros_handler.publish_stop(self.id, False)
         self.ros_handler.publish_omni_move(self.id, speed, angle)
 
     def draw(self, canvas, draw_context):

--- a/vsss_ws/src/strategy/strategy/main.py
+++ b/vsss_ws/src/strategy/strategy/main.py
@@ -14,13 +14,15 @@ simulation = True
 team = "YELLOW"
 
 
-def on_canvas_click(event, ball):
+def on_canvas_click(event, ball, team_robots):
     x, y = ball.world_to_pixel(event.x, event.y)
     ball.real_x = x
     ball.real_y = y
     ball.real_vx = 0
     ball.real_vy = 0
 
+    for robot in team_robots:
+        robot.stop()
 
 def main():
     rclpy.init()
@@ -59,7 +61,14 @@ def main():
     last_pub_time = millis()
     pub_hz = 10
 
-    root.bind("<Button-1>", lambda event: on_canvas_click(event, object_handler.get_ball()))
+    root.bind(
+        "<Button-1>",
+        lambda event: on_canvas_click(
+            event,
+            object_handler.get_ball(),
+            object_handler.get_yellow_robots()
+        )
+    )
 
     def loop():
         nonlocal last_pub_time

--- a/vsss_ws/src/strategy/strategy/ros_handler.py
+++ b/vsss_ws/src/strategy/strategy/ros_handler.py
@@ -1,6 +1,7 @@
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
+from std_msgs.msg import Bool
 import math
 from tf2_ros import TransformException, Buffer, TransformListener
 from sensor_msgs.msg import Image
@@ -68,4 +69,14 @@ class RosHandler(Node):
         msg.linear.x = float(speed * math.cos(angle))
         msg.linear.y = float(speed * math.sin(angle))
         msg.angular.z = 0.0
+        self.publishers_map[topic_name].publish(msg)
+
+    def publish_stop(self, robot_id, value):
+        topic_name = f'/strategy/robot_{robot_id}/stop'
+        if topic_name not in self.publishers_map:
+            self.publishers_map[topic_name] = self.create_publisher(Bool, topic_name, 10)
+
+        msg = Bool()
+        msg.data = value
+
         self.publishers_map[topic_name].publish(msg)


### PR DESCRIPTION
Using the /strategy/robot_{robot_id}/stop topic to publish when the robots should be stopped, this message is received by control and in case of simulator, the command will be intercepted and executed within the simulator physics