### PR TITLE
Added visual markings to main GUI

### DIFF
--- a/vsss_ws/src/vision/vision/detection/coordinates.cpp
+++ b/vsss_ws/src/vision/vision/detection/coordinates.cpp
@@ -119,3 +119,29 @@ cv::Mat Coordinates::get_warped_image(const cv::Mat& input_image) const {
 
 	return warped_image;
 }
+
+cv::Point2f Coordinates::warped_to_pixel(const cv::Point2f& warped_point, int width, int height) const {
+	if (!is_calibrated || homography_matrix.empty()) return {0.0f, 0.0f};
+
+	cv::Mat shift = cv::Mat::eye(3, 3, CV_64F);
+	shift.at<double>(0, 2) = FieldConstants::FIELD_WIDTH_M / 2.0;
+	shift.at<double>(1, 2) = FieldConstants::FIELD_HEIGHT_M / 2.0;
+
+	cv::Mat scale = cv::Mat::eye(3, 3, CV_64F);
+	scale.at<double>(0, 0) = (double)width / FieldConstants::FIELD_WIDTH_M;
+	scale.at<double>(1, 1) = (double)height / FieldConstants::FIELD_HEIGHT_M;
+
+	cv::Mat flip_y = cv::Mat::eye(3, 3, CV_64F);
+	flip_y.at<double>(1, 1) = -1.0;
+	flip_y.at<double>(1, 2) = (double)height;
+
+	cv::Mat final_homography = flip_y * scale * shift * homography_matrix;
+
+	cv::Mat inverse_final_homography = final_homography.inv();
+
+	std::vector<cv::Point2f> src = { warped_point };
+	std::vector<cv::Point2f> dst;
+	cv::perspectiveTransform(src, dst, inverse_final_homography);
+
+	return dst[0];
+}

--- a/vsss_ws/src/vision/vision/detection/coordinates.h
+++ b/vsss_ws/src/vision/vision/detection/coordinates.h
@@ -21,4 +21,5 @@ public:
 	cv::Point meter_to_minimap(const cv::Point2f& meter, int width, int height) const;
 	double meter_to_pixel_scalar(double meter);
 	cv::Mat get_warped_image(const cv::Mat& input_image) const;
+	cv::Point2f warped_to_pixel(const cv::Point2f& warped_point, int width, int height) const;
 };

--- a/vsss_ws/src/vision/vision/detection/tracker.cpp
+++ b/vsss_ws/src/vision/vision/detection/tracker.cpp
@@ -94,9 +94,10 @@ void Tracker::Entity::update(const std::optional<cv::Point2f> observed_pos, cons
 	}
 }
 
-Tracker::Tracker(Coordinates* coordinates, GUI* gui) {
+Tracker::Tracker(Coordinates* coordinates, GUI* gui, Drawer* drawer) {
 	this->coordinates = coordinates;
 	this->gui = gui;
+	this->drawer = drawer;
 	ball.id = 20;
 }
 
@@ -243,14 +244,36 @@ void Tracker::display_debug_image(int width, int height) {
         };
         cv::Point tip_px = coordinates->meter_to_minimap(tip_m, width, height);
 
-        cv::circle(map, center_px, 10, color, 2);
-        cv::arrowedLine(map, center_px, tip_px, color, 2);
+        cv::circle(map, center_px, DRAW_RADIUS, color, DRAW_THICKNESS);
+        cv::arrowedLine(map, center_px, tip_px, color, DRAW_THICKNESS);
+
 
     	int acc_pct = static_cast<int>(r.accuracy * 100.0f);
     	std::string label = "ID:" + std::to_string(r.id) + " (" + std::to_string(acc_pct) + "%)";
 
-    	cv::putText(map, label, center_px + cv::Point(-10, -15),
-			cv::FONT_HERSHEY_SIMPLEX, 0.4, color, 1);
+    	cv::Point origin = center_px + cv::Point(DRAW_TEXT_X_OFFSET, DRAW_TEXT_Y_OFFSET);
+    	cv::putText(map, label, origin,
+			cv::FONT_HERSHEY_SIMPLEX, DRAW_FONT_SCALE, color, 1);
+
+    	drawer->circle(
+    		coordinates->warped_to_pixel(center_px, width, height),
+    		DRAW_RADIUS,
+    		DRAW_THICKNESS,
+    		color, Drawer::Layer::MARKINGS
+    		);
+    	drawer->line(
+    		coordinates->warped_to_pixel(center_px, width, height),
+    		coordinates->warped_to_pixel(tip_px, width, height),
+    		DRAW_THICKNESS,
+    		color,
+    		Drawer::Layer::MARKINGS
+    		);
+    	drawer->text(
+    		label,
+    		coordinates->warped_to_pixel(origin, width, height),
+    		DRAW_FONT_SCALE,
+    		Drawer::Layer::MARKINGS
+    		);
     }
 
 	if (ball.initialized) {

--- a/vsss_ws/src/vision/vision/detection/tracker.h
+++ b/vsss_ws/src/vision/vision/detection/tracker.h
@@ -7,10 +7,17 @@
 #include "gui.h"
 #include "robot_identities.h"
 
+#define DRAW_RADIUS 10
+#define DRAW_THICKNESS 2
+#define DRAW_FONT_SCALE 0.4
+#define DRAW_TEXT_X_OFFSET (-10)
+#define DRAW_TEXT_Y_OFFSET (-15)
+
 class Tracker {
 private:
     Coordinates* coordinates;
     GUI* gui;
+    Drawer* drawer;
     std::set<int> infield_objects;
 
     std::chrono::steady_clock::time_point last_prediction_time;
@@ -43,7 +50,7 @@ public:
         [[nodiscard]] ObjectType team() const;
     };
 
-    Tracker(Coordinates* coordinates, GUI* gui);
+    Tracker(Coordinates* coordinates, GUI* gui, Drawer* drawer);
     void upload_infield_objects(const std::set<int>& infield_objects);
     Entity ball;
     std::map<int, Entity> robots;

--- a/vsss_ws/src/vision/vision/gui/drawer.cpp
+++ b/vsss_ws/src/vision/vision/gui/drawer.cpp
@@ -1,5 +1,6 @@
 #include "drawer.h"
 
+#include <optional>
 #include <utility>
 
 class PlotCmd final : public DrawCommand {
@@ -64,21 +65,42 @@ public:
 };
 
 class TextCmd final : public DrawCommand {
-    std::string txt; cv::Rect roi; float scale; int y_off; bool erase;
+    std::string txt;
+    cv::Rect roi;
+    float scale;
+    int y_off{};
+    bool erase{};
+    std::optional<cv::Point> predefined_org;
 public:
-    TextCmd(std::string t, cv::Rect r, float s, int y, bool e) : txt(std::move(t)), roi(r), scale(s), y_off(y), erase(e) {}
-    void draw(cv::Mat& target) override {
-        if (erase) cv::rectangle(target, roi & cv::Rect(0,0,target.cols,target.rows), cv::Scalar(0,0,0), -1);
+    TextCmd(const std::string &t, const cv::Rect r, const float s, const int y, const bool e) {
+        this->txt = t;
+        this->roi = r;
+        this->scale = s;
+        this->y_off = y;
+        this->erase = e;
+    }
+    TextCmd(const std::string& t, const cv::Point org, const float s) {
+        this->txt = t;
+        this->predefined_org = org;
+        this->scale = s;
+    }
 
-        int baseline = 0;
-        double cur_scale = scale;
-        cv::Size sz = cv::getTextSize(txt, cv::FONT_HERSHEY_SIMPLEX, cur_scale, 1, &baseline);
-        while (sz.width > roi.width && cur_scale > 0.3) {
-            cur_scale -= 0.1;
-            sz = cv::getTextSize(txt, cv::FONT_HERSHEY_SIMPLEX, cur_scale, 1, &baseline);
+    void draw(cv::Mat& target) override {
+        if (predefined_org.has_value()) {
+            cv::putText(target, txt, predefined_org.value(), cv::FONT_HERSHEY_SIMPLEX, scale, cv::Scalar(255,255,255), 1);
+        } else {
+            if (erase) cv::rectangle(target, roi & cv::Rect(0,0,target.cols,target.rows), cv::Scalar(0,0,0), -1);
+
+            int baseline = 0;
+            double cur_scale = scale;
+            cv::Size sz = cv::getTextSize(txt, cv::FONT_HERSHEY_SIMPLEX, cur_scale, 1, &baseline);
+            while (sz.width > roi.width && cur_scale > 0.3) {
+                cur_scale -= 0.1;
+                sz = cv::getTextSize(txt, cv::FONT_HERSHEY_SIMPLEX, cur_scale, 1, &baseline);
+            }
+            cv::Point org(roi.x + (roi.width - sz.width)/2, roi.y + (roi.height + sz.height)/2 + y_off);
+            cv::putText(target, txt, org, cv::FONT_HERSHEY_SIMPLEX, cur_scale, cv::Scalar(255,255,255), 1);
         }
-        cv::Point org(roi.x + (roi.width - sz.width)/2, roi.y + (roi.height + sz.height)/2 + y_off);
-        cv::putText(target, txt, org, cv::FONT_HERSHEY_SIMPLEX, cur_scale, cv::Scalar(255,255,255), 1);
     }
 };
 
@@ -104,6 +126,10 @@ void Drawer::inverse_polyline(const std::vector<cv::Point>& points, const cv::Sc
 
 void Drawer::text(const std::string& content, const cv::Rect& roi, float font_scale, int y_offset, bool erase_bg, Layer layer) {
     queues[layer].push_back(std::make_unique<TextCmd>(content, roi, font_scale, y_offset, erase_bg));
+}
+
+void Drawer::text(const std::string& content, cv::Point org, float font_scale, Layer layer) {
+    queues[layer].push_back(std::make_unique<TextCmd>(content, org, font_scale));
 }
 
 void Drawer::render(cv::Mat& target, const Layer layer) {

--- a/vsss_ws/src/vision/vision/gui/drawer.h
+++ b/vsss_ws/src/vision/vision/gui/drawer.h
@@ -28,6 +28,7 @@ public:
 	void polyline(const std::vector<cv::Point>& points, bool is_closed, int thickness, const cv::Scalar& color, Layer layer);
 	void inverse_polyline(const std::vector<cv::Point>& points, const cv::Scalar& color, const cv::Rect& restriction_roi, Layer layer);
 	void text(const std::string& content, const cv::Rect& roi, float font_scale, int y_offset, bool erase_bg, Layer layer);
+	void text(const std::string& content, cv::Point org, float font_scale, Layer layer);
 
 	void render(cv::Mat& target, Layer layer);
 

--- a/vsss_ws/src/vision/vision/gui/gui.cpp
+++ b/vsss_ws/src/vision/vision/gui/gui.cpp
@@ -1,11 +1,13 @@
 #include "gui.h"
 
-GUI::GUI(AppData* app_data): app_data(app_data) {
+GUI::GUI(AppData* app_data, Drawer* drawer): app_data(app_data) {
 	this->window_name = "default";
+	this->drawer = drawer;
 }
 
-GUI::GUI(AppData* app_data, const std::string& window_name): app_data(app_data) {
+GUI::GUI(AppData* app_data, Drawer* drawer, const std::string& window_name): app_data(app_data) {
 	this->window_name = window_name;
+	this->drawer = drawer;
 }
 
 void GUI::set_window_name(const std::string& window_name) {
@@ -37,7 +39,7 @@ void GUI::upload_frame(cv::Mat &input_frame) {
 	if (app_data->roi_points.size() > 1) {
 		inverse_closed_polyline(app_data->roi_points, Drawer::Layer::PREPROCESSING, {0, 0, 0});
 	}
-	drawer.render(input_frame, Drawer::Layer::PREPROCESSING);
+	drawer->render(input_frame, Drawer::Layer::PREPROCESSING);
 
 	image_bgr.upload(input_frame);
 	preprocessing::filters(image_bgr, image_bgr, image_hsv, app_data->color_params);
@@ -159,7 +161,7 @@ void GUI::text(
 	) {
 
 	const cv::Rect roi = rowspace_roi(rowspace);
-	drawer.text(text, roi, font_scale, y_offset, erase_rowspace, layer);
+	drawer->text(text, roi, font_scale, y_offset, erase_rowspace, layer);
 }
 
 void GUI::display_frame() {
@@ -170,7 +172,7 @@ void GUI::display_frame() {
 	cudaDeviceSynchronize();
 	image_bgr.download(cpu_image_bgr);
 
-	drawer.render(cpu_image_bgr, Drawer::Layer::MARKINGS);
+	drawer->render(cpu_image_bgr, Drawer::Layer::MARKINGS);
 	cv::Mat image_view = cpu_image_bgr(viewport);
 	cv::resize(image_view, image_view, cv::Size(image_width, total_height), 0, 0, cv::INTER_LINEAR);
 
@@ -181,7 +183,7 @@ void GUI::display_frame() {
 
 	sidebar.copyTo(display_buffer(sidebar_rect));
 
-	drawer.render(display_buffer, Drawer::Layer::INTERFACE);
+	drawer->render(display_buffer, Drawer::Layer::INTERFACE);
 
 	{
 		fps_timer.stop();
@@ -217,25 +219,25 @@ void GUI::display_frame() {
 
 void GUI::plot(const cv::Point &point, const Drawer::Layer layer, const cv::Scalar &color) {
 	if (!valid_coordinate(point)) return;
-	drawer.plot(point, color, layer);
+	drawer->plot(point, color, layer);
 }
 
 
 void GUI::solid_circle(const cv::Point& center, const int radius, const Drawer::Layer layer, const cv::Scalar& color) {
 	if (!valid_coordinate(center)) return;
-	drawer.circle(center, radius, cv::FILLED, color, layer);
+	drawer->circle(center, radius, cv::FILLED, color, layer);
 }
 
 void GUI::hollow_circle(const cv::Point& center, const int radius, const Drawer::Layer layer, const int thickness, const cv::Scalar& color) {
 	if (!valid_coordinate(center)) return;
-	drawer.circle(center, radius, thickness, color, layer);
+	drawer->circle(center, radius, thickness, color, layer);
 }
 
 void GUI::line(const cv::Point& point1, const cv::Point& point2, const Drawer::Layer layer, const int thickness, const cv::Scalar& color) {
 	if (!valid_coordinate(point1)) return;
 	if (!valid_coordinate(point2)) return;
 
-	drawer.line(point1, point2, thickness, color, layer);
+	drawer->line(point1, point2, thickness, color, layer);
 }
 
 void GUI::polyline(
@@ -247,7 +249,7 @@ void GUI::polyline(
 	if (points.size() <= 1) return;
 	if (!valid_coordinate(points)) return;
 
-	drawer.polyline(points, false, thickness, color, layer);
+	drawer->polyline(points, false, thickness, color, layer);
 }
 
 void GUI::closed_polyline(
@@ -260,7 +262,7 @@ void GUI::closed_polyline(
 	if (points.size() <= 1) return;
 	if (!valid_coordinate(points)) return;
 
-	drawer.polyline(points, true, thickness, color, layer);
+	drawer->polyline(points, true, thickness, color, layer);
 }
 
 void GUI::inverse_closed_polyline(
@@ -273,7 +275,7 @@ void GUI::inverse_closed_polyline(
 	if (!valid_coordinate(points)) return;
 
 	cv::Rect image_area(0, 0, image_width, total_height);
-	drawer.inverse_polyline(points, color, image_area, layer);
+	drawer->inverse_polyline(points, color, image_area, layer);
 }
 
 

--- a/vsss_ws/src/vision/vision/gui/gui.h
+++ b/vsss_ws/src/vision/vision/gui/gui.h
@@ -11,7 +11,7 @@
 class GUI {
 private:
 	AppData* app_data;
-	Drawer drawer;
+	Drawer* drawer;
 
 	std::string window_name{};
 	cv::Mat image_with_gui;
@@ -31,8 +31,8 @@ private:
 	double current_fps = 0.0;
 	int frame_counter = 0;
 public:
-	explicit GUI(AppData* app_data);
-	GUI(AppData* app_data, const std::string& window_name);
+	GUI(AppData* app_data, Drawer* drawer);
+	GUI(AppData* app_data, Drawer* drawer, const std::string& window_name);
 
 	void set_window_name(const std::string& window_name);
 	void free_rowspace(int rowspace);

--- a/vsss_ws/src/vision/vision/gui/interface_manager.cpp
+++ b/vsss_ws/src/vision/vision/gui/interface_manager.cpp
@@ -144,6 +144,10 @@ void InterfaceManager::init_widgets() {
 		color_calibrator->save_calibration(app_data->calibration_filename);
 		coordinates->update_matrix();
 	}));
+
+	detection_tool_widgets.push_back(std::make_unique<Button>(gui, 9, "VOLVER", [this]() {
+		app_data->current_state = AppState::MAIN_MENU;
+	}));
 }
 
 void InterfaceManager::save_current_blob_calibration() {
@@ -231,6 +235,7 @@ void InterfaceManager::draw_interface() {
     		break;
         case AppState::DETECTION:
             gui->text("MODO DETECTION (ESC para salir)", 1, Drawer::Layer::INTERFACE, 0.6, false);
+    		current_widgets = &detection_tool_widgets;
             break;
     }
 	// detector->display_debug_info();
@@ -294,6 +299,7 @@ void InterfaceManager::handle_input(int event, int x, int y) {
     	case AppState::COLOR_CALIBRATING: current_widgets = &color_calibration_tool_widgets; break;
     	case AppState::MASK_CALIBRATING: current_widgets = &mask_calibration_tool_widgets; break;
     	case AppState::ROI_CALIBRATING: current_widgets = &roi_calibration_tool_widgets; break;
+    	case AppState::DETECTION: current_widgets = &detection_tool_widgets; break;
         default: break;
     }
 

--- a/vsss_ws/src/vision/vision/gui/interface_manager.h
+++ b/vsss_ws/src/vision/vision/gui/interface_manager.h
@@ -36,6 +36,7 @@ private:
 	std::vector<std::unique_ptr<Widget>> camera_calibration_tool_widgets;
 	std::vector<std::unique_ptr<Widget>> mask_calibration_tool_widgets;
 	std::vector<std::unique_ptr<Widget>> roi_calibration_tool_widgets;
+	std::vector<std::unique_ptr<Widget>> detection_tool_widgets;
 
 	std::map<std::string, Button*> color_buttons;
 	std::optional<CalibrationResult> last_calculated_result;

--- a/vsss_ws/src/vision/vision/main.cpp
+++ b/vsss_ws/src/vision/vision/main.cpp
@@ -83,9 +83,10 @@ int main(int argc, char * argv[]) {
     cv::VideoWriter processed_writer;
 
     AppData app_data;
-    GUI gui(&app_data, window_name);
+    Drawer drawer;
+    GUI gui(&app_data, &drawer, window_name);
     Coordinates coordinates(&app_data);
-    Tracker tracker(&coordinates, &gui);
+    Tracker tracker(&coordinates, &gui, &drawer);
     BlobCalibrator blob_calibrator(&gui, &app_data);
     ColorCalibrator color_calibrator(&gui, &app_data);
     CameraCalibrator camera_calibrator(&app_data, &cap, &use_camera);


### PR DESCRIPTION
This PR introduces a new visual way to display the detections in the main GUI panel from the vision node. This will help debug strategy without starting all the debug windows that may consume resources 

<img width="1226" height="961" alt="image" src="https://github.com/user-attachments/assets/4b6ddc83-3da6-433d-b7ee-602fa5d24831" />
